### PR TITLE
fix(ui): prevent context menu from being cut off (#1)

### DIFF
--- a/frontend/components/FileGridItem.tsx
+++ b/frontend/components/FileGridItem.tsx
@@ -40,6 +40,7 @@ export const FileGridItem: React.FC<FileGridItemProps> = ({
   const IconComp = getFileIcon(file.filename);
   const isImg = isImageFile(file.filename);
   const isActive = activeMenuId === file.id;
+  const [menuPosition, setMenuPosition] = React.useState<'top' | 'bottom'>('bottom');
 
   return (
     <div 
@@ -78,14 +79,26 @@ export const FileGridItem: React.FC<FileGridItemProps> = ({
        {/* Action Menu (Absolute Positioned with High Z-Index) */}
        <div className={`absolute top-2 right-2 z-[1000] transition-all duration-200 action-menu ${isActive ? 'opacity-100 scale-100' : 'opacity-0 scale-90 group-hover:opacity-100 group-hover:scale-100'}`}>
           <button 
-              onClick={(e) => { e.stopPropagation(); setActiveMenuId(isActive ? null : file.id); }}
+              onClick={(e) => { 
+                e.stopPropagation(); 
+                if (!isActive) {
+                    const rect = e.currentTarget.getBoundingClientRect();
+                    const spaceBelow = window.innerHeight - rect.bottom;
+                    setMenuPosition(spaceBelow < 300 ? 'top' : 'bottom'); // 300px threshold for menu height
+                }
+                setActiveMenuId(isActive ? null : file.id); 
+              }}
               className={`p-1.5 rounded-lg backdrop-blur-md transition-colors ${isActive ? 'bg-white/20 text-white' : 'bg-black/40 text-white/80 hover:bg-black/60 hover:text-white'}`}
           >
               <MoreVertical size={14} />
           </button>
            {/* Dropdown Menu */}
            {isActive && (
-              <div className="absolute right-0 top-full mt-2 w-48 glass-heavy border border-white/10 rounded-xl shadow-2xl overflow-hidden z-[9999] animate-in fade-in zoom-in-95 duration-200 flex flex-col p-1.5 ring-1 ring-black/5">
+              <div className={`absolute right-0 w-48 glass-heavy border border-white/10 rounded-xl shadow-2xl overflow-hidden z-[9999] animate-in fade-in zoom-in-95 duration-200 flex flex-col p-1.5 ring-1 ring-black/5 ${
+                  menuPosition === 'top' 
+                      ? 'bottom-full mb-2 origin-bottom-right' 
+                      : 'top-full mt-2 origin-top-right'
+              }`}>
                    <div className="flex flex-col gap-0.5">
                        <button onClick={() => handlePin(file)} className="w-full flex items-center gap-2.5 px-3 py-2 text-xs font-medium text-slate-300 hover:text-white hover:bg-white/10 rounded-lg transition-colors">
                            {file.is_pinned ? <PinOff size={14} className="text-amber-500" /> : <Pin size={14} className="text-slate-400" />} {file.is_pinned ? (t('unpin') || 'Unpin') : (t('pin') || 'Pin')}


### PR DESCRIPTION
Fixes #1

- Reposition menu when near viewport bottom
- Prevent overflow clipping
